### PR TITLE
[Fix #1186] Allow any type in for.in inline array

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -689,7 +689,7 @@ Allows workflows to iterate over a collection of items, executing a defined set 
 | Name | Type | Required | Description|
 |:--|:---:|:---:|:---|
 | for.each | `string` | `no` | The name of the variable used to store the current item being enumerated.<br>Defaults to `item`. |
-| for.in | `string` \| `array<object>` | `yes` | A [runtime expression](dsl.md#runtime-expressions) or an inline array of objects used to get the collection to enumerate. |
+| for.in | `string` \| `array` | `yes` | A [runtime expression](dsl.md#runtime-expressions) or an inline array used to get the collection to enumerate. |
 | for.at | `string` | `no` | The name of the variable used to store the index of the current item being enumerated.<br>Defaults to `index`. |
 | while | `string` | `no` | A [runtime expression](dsl.md#runtime-expressions) that represents the condition, if any, that must be met for the iteration to continue. |
 | do | [`map[string, task]`](#task) | `yes` | The [task(s)](#task) to perform for each item in the collection. |

--- a/examples/for-inline-primitive-array.yaml
+++ b/examples/for-inline-primitive-array.yaml
@@ -1,0 +1,17 @@
+document:
+  dsl: '1.0.3'
+  namespace: test
+  name: for-inline-primitive-array-example
+  version: '0.1.0'
+do:
+  - sumNumbers:
+      for:
+        each: number
+        in:
+          - 1
+          - 2
+          - 3
+      do:
+        - add:
+            set:
+              sum: '${ .sum + $number }'

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -711,9 +711,8 @@ $defs:
                   description: A runtime expression used to get the collection to enumerate.
                 - type: array
                   title: ForInInlineArray
-                  description: An inline array of objects to enumerate.
+                  description: An inline array to enumerate.
                   items:
-                    type: object
                     description: An item in the inline collection.
             at:
               type: string


### PR DESCRIPTION
## Summary
- Removes the `type: object` constraint from inline array items in `for.in`, allowing iteration over arrays of any type (strings, numbers, booleans, objects, etc.)
- Updates the DSL reference to reflect the type change from `array<object>` to `array`
- Adds a new example (`for-inline-primitive-array.yaml`) demonstrating iteration over an inline array of numbers

Fixes #1186

## Test plan
- [x] All 185 schema validation tests pass
- [ ] Verify the new example validates correctly in CI