### PR TITLE
[Fix #1188] Replace serverlessworkflow references with open-workflow-specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![contributions Welcome](https://img.shields.io/badge/Contributions-Welcome-green.svg?style=flat)](https://github.com/serverlessworkflow/specification/issues)
-[![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/serverlessworkflow/specification/blob/master/LICENSE)
-[<img alt="GitHub Release" src="https://img.shields.io/github/v/release/serverlessworkflow/specification?label=Release">](https://github.com/serverlessworkflow/specification/releases/latest)
+[![contributions Welcome](https://img.shields.io/badge/Contributions-Welcome-green.svg?style=flat)](https://github.com/open-workflow-specification/specification/issues)
+[![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/open-workflow-specification/specification/blob/master/LICENSE)
+[<img alt="GitHub Release" src="https://img.shields.io/github/v/release/open-workflow-specification/specification?label=Release">](https://github.com/open-workflow-specification/specification/releases/latest)
 <br>
 [<img src="https://img.shields.io/badge/Website-blue?style=flat&logo=google-chrome&logoColor=white">](https://open-workflow-specification.org/) 
 [<img src="https://img.shields.io/badge/Slack-4A154B?style=flat&logo=slack&logoColor=white">](https://cloud-native.slack.com/messages/open-workflow) 
@@ -73,13 +73,13 @@ These SDKs empower developers to seamlessly integrate workflows into their appli
 
 Explore our SDKs for different programming languages:
 
-- [.NET](https://github.com/serverlessworkflow/sdk-net)
-- [Go](https://github.com/serverlessworkflow/sdk-go)
-- [Java](https://github.com/serverlessworkflow/sdk-java)
-- [PHP](https://github.com/serverlessworkflow/sdk-php)
-- [Python](https://github.com/serverlessworkflow/sdk-python)
-- [Rust](https://github.com/serverlessworkflow/sdk-rust)
-- [TypeScript](https://github.com/serverlessworkflow/sdk-typescript)
+- [.NET](https://github.com/open-workflow-specification/sdk-net)
+- [Go](https://github.com/open-workflow-specification/sdk-go)
+- [Java](https://github.com/open-workflow-specification/sdk-java)
+- [PHP](https://github.com/open-workflow-specification/sdk-php)
+- [Python](https://github.com/open-workflow-specification/sdk-python)
+- [Rust](https://github.com/open-workflow-specification/sdk-rust)
+- [TypeScript](https://github.com/open-workflow-specification/sdk-typescript)
 
 Don't see your favorite implementation on the list? Shout out to the community about it or, even better, contribute to the ecosystem with a new SDK!
 
@@ -90,15 +90,15 @@ No matter your preferred language, our SDKs provide the tools you need to levera
 | Name | About |
 | --- | --- |
 | [Apache KIE SonataFlow](https://sonataflow.org) | Apache KIE SonataFlow is a tool for building cloud-native workflow applications. You can use it to do the services and events orchestration and choreography. |
-| [Java SDK reference implementation](https://github.com/serverlessworkflow/sdk-java/tree/main/impl) | Full compliant Java implementation of the specification |
+| [Java SDK reference implementation](https://github.com/open-workflow-specification/sdk-java/tree/main/impl) | Full compliant Java implementation of the specification |
 | [Lemline](https://github.com/lemline/lemline) | Lemline is a highly scalable runtime running on top of your existing messaging infrastructure. |
-| [Synapse](https://github.com/serverlessworkflow/synapse) | Synapse is a scalable, cross-platform, fully customizable platform for managing and running workflows defined with Open Workflow Specification. |
+| [Synapse](https://github.com/open-workflow-specification/synapse) | Synapse is a scalable, cross-platform, fully customizable platform for managing and running workflows defined with Open Workflow Specification. |
 
 ### Tooling
 
 In order to enhance developer experience with the Open Workflow DSL, we provide a [Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=serverlessworkflow.serverless-workflow-vscode-extension).
 
-The sources of the extension can be found [here](https://github.com/serverlessworkflow/vscode-extension).
+The sources of the extension can be found [here](https://github.com/open-workflow-specification/vscode-extension).
 
 ### CNCF Landscape
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 The Open Workflow Specification team and community take security bugs very seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
 
-To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/serverlessworkflow/specification/security/advisories/new) tab.
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/open-workflow-specification/specification/security/advisories/new) tab.
 
 The Open Workflow Specification team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 
@@ -18,7 +18,7 @@ To help ensure the security of your workflows, we recommend the following best p
 - **Monitor and Audit**: Continuously monitor and audit workflows to detect and respond to any suspicious activities.
 - **Secure External Resources**: Ensure that any resources external to a workflow definition are always secured using modern authentication policies as defined in the DSL.
 - **Use Trusted Containers and Scripts**: When relying on [run tasks](dsl-reference.md#run), only use trusted container images, scripts, commands and workflows.
-- **Custom Functions**: Only use custom functions from the [Open Workflow Catalog](https://github.com/serverlessworkflow/catalog) or from trusted sources to avoid introducing vulnerabilities.
+- **Custom Functions**: Only use custom functions from the [Open Workflow Catalog](https://github.com/open-workflow-specification/catalog) or from trusted sources to avoid introducing vulnerabilities.
   
 ---
 

--- a/adr/v1.0-adr-migration-tool.md
+++ b/adr/v1.0-adr-migration-tool.md
@@ -6,7 +6,7 @@ Proposed
 
 ## Related Issue
 
-[#1149](https://github.com/serverlessworkflow/specification/issues/1149) - Proposal: Official Migration Tool for 0.8/0.9 to 1.0.0 Workflows
+[#1149](https://github.com/open-workflow-specification/specification/issues/1149) - Proposal: Official Migration Tool for 0.8/0.9 to 1.0.0 Workflows
 
 ## Context
 
@@ -408,8 +408,8 @@ swf-migrate workflow.json --strict
 
 ## References
 
-- [Open Workflow 0.8 Specification](https://github.com/serverlessworkflow/specification/tree/0.8.x)
-- [Open Workflow 0.9 Specification](https://github.com/serverlessworkflow/specification/tree/0.9.x)
-- [Open Workflow 1.0.0 Specification](https://github.com/serverlessworkflow/specification)
+- [Open Workflow 0.8 Specification](https://github.com/open-workflow-specification/specification/tree/0.8.x)
+- [Open Workflow 0.9 Specification](https://github.com/open-workflow-specification/specification/tree/0.9.x)
+- [Open Workflow 1.0.0 Specification](https://github.com/open-workflow-specification/specification)
 - [JsonPath Specification](https://goessner.net/articles/JsonPath/)
 - [jq Manual](https://jqlang.github.io/jq/manual/)

--- a/adr/v1.0-adr-shared-workflow-editor.md
+++ b/adr/v1.0-adr-shared-workflow-editor.md
@@ -26,7 +26,7 @@ multiple vendors/maintainers to contribute and embed it.
 
 This ADR formalizes the decision to build a shared editor, with a strictly
 scoped MVP, aligned with the proposal outlined in
-[serverlessworkflow/specification#1131](https://github.com/serverlessworkflow/specification/issues/1131) and further refined through MVP
+[serverlessworkflow/specification#1131](https://github.com/open-workflow-specification/specification/issues/1131) and further refined through MVP
 scoping discussions.
 
 ## Decision

--- a/contributing.md
+++ b/contributing.md
@@ -13,13 +13,13 @@ well as the guidelines we follow for how our documents are formatted.
 ## Reporting an Issue
 
 If you have a question, consider opening a
-[discussion](https://github.com/serverlessworkflow/specification/discussions).
+[discussion](https://github.com/open-workflow-specification/specification/discussions).
 
 To report an issue or to suggest an idea for a change that you haven't had time
 to write up yet, open an
-[issue](https://github.com/serverlessworkflow/specification/issues). It is best
+[issue](https://github.com/open-workflow-specification/specification/issues). It is best
 to check our existing
-[issues](https://github.com/serverlessworkflow/specification/issues) first to
+[issues](https://github.com/open-workflow-specification/specification/issues) first to
 see if a similar one has already been opened and discussed.
 
 ## Suggesting a Change
@@ -29,12 +29,12 @@ glance, requiring some discussions with other contributors before reaching a
 conclusion.
 
 Before opening a pull request, we kindly ask you to consider opening a
-[discussion](https://github.com/serverlessworkflow/specification/discussions)
-or an [issue](https://github.com/serverlessworkflow/specification/issues). The
+[discussion](https://github.com/open-workflow-specification/specification/discussions)
+or an [issue](https://github.com/open-workflow-specification/specification/issues). The
 community will be more than happy to discuss your proposals there.
 
 Having the discussion or issue settled, please submit a
-[pull request](https://github.com/serverlessworkflow/specification/pulls) (PR)
+[pull request](https://github.com/open-workflow-specification/specification/pulls) (PR)
 with the complete set of changes discussed with the community. See the
 [Spec Formatting Conventions](#spec-formatting-conventions) section for the
 guidelines we follow for how documents are formatted.
@@ -46,7 +46,7 @@ discussion.
 
 Due to the amount of text a specification can have, typos, spelling, and
 formatting issues are pretty common. In these cases, please submit a
-[pull request](https://github.com/serverlessworkflow/specification/pulls)
+[pull request](https://github.com/open-workflow-specification/specification/pulls)
 directly only with the fixes that you see fit.
 
 ### Assigning and Owning work

--- a/ctk/README.md
+++ b/ctk/README.md
@@ -46,7 +46,7 @@ Conformance testing is the process of verifying that an implementation adheres t
 1. **Clone the Repository**: Start by cloning the Open Workflow CTK repository to your local machine.
    
 ```sh
-git clone https://github.com/serverlessworkflow/specification.git
+git clone https://github.com/open-workflow-specification/specification.git
 ```
 
 2. **Install Dependencies**: Ensure that you have all the necessary dependencies installed. This typically involves setting up a testing framework that can execute Gherkin tests.

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -1472,7 +1472,7 @@ The data carried by the cloud event that notifies that the status phase of a wor
 |:--|:---:|:---:|:---|
 | name | `string` | `yes` | The qualified name of the workflow which's status phase has changed. |
 | updatedAt | `dateTime` | `yes` | The date and time at which the workflow's status phase has changed. |
-| status | `string` | The workflow's current [status phase](https://github.com/serverlessworkflow/specification/blob/main/dsl.md#status-phases). |
+| status | `string` | The workflow's current [status phase](https://github.com/open-workflow-specification/specification/blob/main/dsl.md#status-phases). |
 
 ###### Examples
 
@@ -1662,7 +1662,7 @@ The data carried by the cloud event that notifies that the status phase of a tas
 | workflow | `string` | `yes` | The qualified name of the workflow the task which's status phase has changed belongs to. |
 | task | `uri` | `yes` | A JSON Pointer that references the task which's status phase has changed. |
 | updatedAt | `dateTime` | `yes` | The date and time at which the task's status phase has changed. |
-| status | `string` | The task's current [status phase](https://github.com/serverlessworkflow/specification/blob/main/dsl.md#status-phases). |
+| status | `string` | The task's current [status phase](https://github.com/open-workflow-specification/specification/blob/main/dsl.md#status-phases). |
 
 ###### Examples
 
@@ -1957,9 +1957,9 @@ do:
 
 A **resource catalog** is an external collection of reusable components, such as functions, that can be referenced and imported into workflows. Catalogs allow workflows to integrate with externally defined resources, making it easier to manage reuse and versioning across different workflows.
 
-Each catalog is defined by an `endpoint` property, specifying the root URL where the resources are hosted, enabling workflows to access external functions and services. For portability, catalogs must adhere to a specific file structure, as defined [here](https://github.com/serverlessworkflow/catalog?tab=readme-ov-file#structure).
+Each catalog is defined by an `endpoint` property, specifying the root URL where the resources are hosted, enabling workflows to access external functions and services. For portability, catalogs must adhere to a specific file structure, as defined [here](https://github.com/open-workflow-specification/catalog?tab=readme-ov-file#structure).
 
-For more information about catalogs, refer to the [Open Workflow DSL document](https://github.com/serverlessworkflow/specification/blob/main/dsl.md#catalogs).
+For more information about catalogs, refer to the [Open Workflow DSL document](https://github.com/open-workflow-specification/specification/blob/main/dsl.md#catalogs).
 
 #### Properties
 
@@ -1979,7 +1979,7 @@ use:
   catalogs:
     global:
       endpoint:
-        uri: https://github.com/serverlessworkflow/catalog
+        uri: https://github.com/open-workflow-specification/catalog
         authentication:
           basic:
             username: user
@@ -2766,7 +2766,7 @@ do:
                     event:
                       with:
                         source: https://open-workflow-specification.org/samples
-                        type: io.serverlessworkflow.samples.asyncapi.message.consumed.v1
+                        type: io.open-workflow-specification.samples.asyncapi.message.consumed.v1
                         data:
                           message: '${ $message }'
 ```

--- a/dsl.md
+++ b/dsl.md
@@ -100,7 +100,7 @@ Both workflows and tasks in the Open Workflow DSL can exist in several phases, e
 | --- | --- |
 | `pending` |	The workflow/task has been initiated and is pending execution. |
 | `running` |	The workflow/task is currently in progress. |
-| `waiting` |	The workflow/task execution is temporarily paused, awaiting either inbound event(s) or a specified time interval as defined by a [`wait`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#wait) task. |
+| `waiting` |	The workflow/task execution is temporarily paused, awaiting either inbound event(s) or a specified time interval as defined by a [`wait`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#wait) task. |
 | `suspended` |	The workflow/task execution has been manually paused by a user and will remain halted until explicitly resumed. |
 | `cancelled` |	The workflow/task execution has been terminated before completion. |
 | `faulted` |	The workflow/task execution has encountered an error. |
@@ -120,35 +120,35 @@ Runtimes are expected to publish these events upon state changes. While using th
 
 | Type | Data | Required | Description |
 |:----:|:----:|:--------:|:------------|
-| <pre>`io.serverlessworkflow.workflow.started.v1`</pre> | [`workflowStartedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#workflow-started-event) | `yes` | Notifies about the start of a workflow. |
-| <pre>`io.serverlessworkflow.workflow.suspended.v1`</pre> | [`workflowSupsendedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#workflow-suspended-event) | `yes` | Notifies about suspending a workflow execution. |
-| <pre>`io.serverlessworkflow.workflow.resumed.v1`</pre> | [`workflowResumedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#workflow-resumed-event) | `yes` | Notifies about resuming a workflow execution. |
-| <pre>`io.serverlessworkflow.workflow.correlation-started.v1`</pre> | [`workflowCorrelationStartedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#workflow-correlation-started-event) | `yes` | Notifies about a workflow starting to correlate events. |
-| <pre>`io.serverlessworkflow.workflow.correlation-completed.v1`</pre> | [`workflowCorrelationCompletedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#workflow-correlation-completed-event) | `yes` | Notifies about a workflow completing an event correlation. |
-| <pre>`io.serverlessworkflow.workflow.cancelled.v1`</pre> | [`workflowCancelledEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#workflow-cancelled-event) | `yes` | Notifies about the cancellation of a workflow execution. |
-| <pre>`io.serverlessworkflow.workflow.faulted.v1`</pre> | [`workflowFaultedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#workflow-faulted-event) | `yes` | Notifies about a workflow being faulted. |
-| <pre>`io.serverlessworkflow.workflow.completed.v1`</pre> | [`workflowCompletedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#workflow-completed-event) | `yes` |Notifies about the completion of a workflow execution. |
-| <pre>`io.serverlessworkflow.workflow.status-changed.v1`</pre> | [`workflowStatusChangedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#workflow-status-changed-event) | `no` |Notifies about the change of a workflow's status phase. |
+| <pre>`io.open-workflow-specification.workflow.started.v1`</pre> | [`workflowStartedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#workflow-started-event) | `yes` | Notifies about the start of a workflow. |
+| <pre>`io.open-workflow-specification.workflow.suspended.v1`</pre> | [`workflowSupsendedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#workflow-suspended-event) | `yes` | Notifies about suspending a workflow execution. |
+| <pre>`io.open-workflow-specification.workflow.resumed.v1`</pre> | [`workflowResumedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#workflow-resumed-event) | `yes` | Notifies about resuming a workflow execution. |
+| <pre>`io.open-workflow-specification.workflow.correlation-started.v1`</pre> | [`workflowCorrelationStartedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#workflow-correlation-started-event) | `yes` | Notifies about a workflow starting to correlate events. |
+| <pre>`io.open-workflow-specification.workflow.correlation-completed.v1`</pre> | [`workflowCorrelationCompletedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#workflow-correlation-completed-event) | `yes` | Notifies about a workflow completing an event correlation. |
+| <pre>`io.open-workflow-specification.workflow.cancelled.v1`</pre> | [`workflowCancelledEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#workflow-cancelled-event) | `yes` | Notifies about the cancellation of a workflow execution. |
+| <pre>`io.open-workflow-specification.workflow.faulted.v1`</pre> | [`workflowFaultedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#workflow-faulted-event) | `yes` | Notifies about a workflow being faulted. |
+| <pre>`io.open-workflow-specification.workflow.completed.v1`</pre> | [`workflowCompletedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#workflow-completed-event) | `yes` |Notifies about the completion of a workflow execution. |
+| <pre>`io.open-workflow-specification.workflow.status-changed.v1`</pre> | [`workflowStatusChangedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#workflow-status-changed-event) | `no` |Notifies about the change of a workflow's status phase. |
 
 > [!NOTE]  
-> The `io.serverlessworkflow.workflow.status-changed.v1` event is an optional convenience event that notifies consumers solely about a workflow’s status changes, without carrying extra data. It is typically used by consumers who only need to track or report status updates (and not details like faults or outputs). Its use is optional because it requires runtimes to publish an additional event for each necessary lifecycle change.
+> The `io.open-workflow-specification.workflow.status-changed.v1` event is an optional convenience event that notifies consumers solely about a workflow’s status changes, without carrying extra data. It is typically used by consumers who only need to track or report status updates (and not details like faults or outputs). Its use is optional because it requires runtimes to publish an additional event for each necessary lifecycle change.
 
 ##### Task Lifecycle Events
 
 | Type | Data | Required | Description |
 |:----:|:----:|:--------:|:------------|
-| <pre>`io.serverlessworkflow.task.created.v1`</pre> | [`taskCreatedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#task-created-event) | `yes` | Notifies about the creation of a task. |
-| <pre>`io.serverlessworkflow.task.started.v1`</pre> | [`taskStartedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#task-started-event) | `yes` | Notifies about the start of a task. |
-| <pre>`io.serverlessworkflow.task.suspended.v1`</pre> | [`taskSuspendedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#task-suspended-event) | `yes` | Notifies about suspending a task's execution. |
-| <pre>`io.serverlessworkflow.task.resumed.v1`</pre> | [`taskResumedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#task-resumed-event) | `yes` | Notifies about resuming a task's execution. |
-| <pre>`io.serverlessworkflow.task.retried.v1`</pre> | [`taskRetriedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#task-retried-event) | `yes` | Notifies about retrying a task's execution. |
-| <pre>`io.serverlessworkflow.task.cancelled.v1`</pre> | [`taskCancelledEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#task-cancelled-event) | `yes` | Notifies about the cancellation of a task's execution. |
-| <pre>`io.serverlessworkflow.task.faulted.v1`</pre> | [`taskFaultedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#task-faulted-event) | `yes` | Notifies about a task being faulted. |
-| <pre>`io.serverlessworkflow.task.completed.v1`</pre> | [`taskCompletedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#task-completed-event) | `yes` | Notifies about the completion of a task's execution. |
-| <pre>`io.serverlessworkflow.task.status-changed.v1`</pre> | [`taskStatusChangedEvent`](https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#task-status-changed-event) | `no` | Notifies about the change of a task's status phase. |
+| <pre>`io.open-workflow-specification.task.created.v1`</pre> | [`taskCreatedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#task-created-event) | `yes` | Notifies about the creation of a task. |
+| <pre>`io.open-workflow-specification.task.started.v1`</pre> | [`taskStartedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#task-started-event) | `yes` | Notifies about the start of a task. |
+| <pre>`io.open-workflow-specification.task.suspended.v1`</pre> | [`taskSuspendedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#task-suspended-event) | `yes` | Notifies about suspending a task's execution. |
+| <pre>`io.open-workflow-specification.task.resumed.v1`</pre> | [`taskResumedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#task-resumed-event) | `yes` | Notifies about resuming a task's execution. |
+| <pre>`io.open-workflow-specification.task.retried.v1`</pre> | [`taskRetriedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#task-retried-event) | `yes` | Notifies about retrying a task's execution. |
+| <pre>`io.open-workflow-specification.task.cancelled.v1`</pre> | [`taskCancelledEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#task-cancelled-event) | `yes` | Notifies about the cancellation of a task's execution. |
+| <pre>`io.open-workflow-specification.task.faulted.v1`</pre> | [`taskFaultedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#task-faulted-event) | `yes` | Notifies about a task being faulted. |
+| <pre>`io.open-workflow-specification.task.completed.v1`</pre> | [`taskCompletedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#task-completed-event) | `yes` | Notifies about the completion of a task's execution. |
+| <pre>`io.open-workflow-specification.task.status-changed.v1`</pre> | [`taskStatusChangedEvent`](https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#task-status-changed-event) | `no` | Notifies about the change of a task's status phase. |
 
 > [!NOTE]  
-> The `io.serverlessworkflow.task.status-changed.v1` event is an optional convenience event that notifies consumers solely about a task's status changes, without carrying extra data. It is typically used by consumers who only need to track or report status updates (and not details like faults or outputs). Its use is optional because it requires runtimes to publish an additional event for each necessary lifecycle change.
+> The `io.open-workflow-specification.task.status-changed.v1` event is an optional convenience event that notifies consumers solely about a task's status changes, without carrying extra data. It is typically used by consumers who only need to track or report status updates (and not details like faults or outputs). Its use is optional because it requires runtimes to publish an additional event for each necessary lifecycle change.
 
 #### Components
 
@@ -526,18 +526,18 @@ Each catalog is defined by an `endpoint` property that specifies the root URL wh
 
 #### File Structure
 
-To ensure portability and standardization, catalogs must follow a specific file structure, which is documented [here](https://github.com/serverlessworkflow/catalog?tab=readme-ov-file#structure). This file structure ensures that runtimes can correctly interpret and resolve the resources contained within a catalog.
+To ensure portability and standardization, catalogs must follow a specific file structure, which is documented [here](https://github.com/open-workflow-specification/catalog?tab=readme-ov-file#structure). This file structure ensures that runtimes can correctly interpret and resolve the resources contained within a catalog.
 
-If a catalog is hosted in a GitHub or GitLab repository, runtimes are expected to resolve the **raw** machine-readable documents that define the cataloged resources. For example, for the function `log:1.0.0` located in a catalog at `https://github.com/serverlessworkflow/catalog/tree/main`, the function definition URI:
+If a catalog is hosted in a GitHub or GitLab repository, runtimes are expected to resolve the **raw** machine-readable documents that define the cataloged resources. For example, for the function `log:1.0.0` located in a catalog at `https://github.com/open-workflow-specification/catalog/tree/main`, the function definition URI:
 
 ```
-https://github.com/serverlessworkflow/catalog/tree/main/functions/log/1.0.0/function.yaml
+https://github.com/open-workflow-specification/catalog/tree/main/functions/log/1.0.0/function.yaml
 ```
 
 Should be transformed by the runtime to point to the raw content of the document:
 
 ```
-https://raw.githubusercontent.com/serverlessworkflow/catalog/refs/heads/main/functions/log/1.0.0/function.yaml
+https://raw.githubusercontent.com/open-workflow-specification/catalog/refs/heads/main/functions/log/1.0.0/function.yaml
 ```
 
 This transformation ensures that runtimes can retrieve and process the actual content of the resource definitions in a machine-readable format. It also ensures that authors can use the standard, user-friendly URIs of such Git repositories, making it easier to reference and manage resources without needing to directly use the raw content links.
@@ -577,7 +577,7 @@ use:
   catalogs:
     global:
       endpoint:
-        uri: https://github.com/serverlessworkflow/catalog
+        uri: https://github.com/open-workflow-specification/catalog
         authentication:
           basic:
             username: user
@@ -658,9 +658,9 @@ run:
 
 4. Commit and push your function to your repository.
 
-5. Optionally, submit your function to the [Open Workflow Catalog](https://github.com/serverlessworkflow/catalog), allowing users to find your function.
+5. Optionally, submit your function to the [Open Workflow Catalog](https://github.com/open-workflow-specification/catalog), allowing users to find your function.
 
-For more information about authoring a new custom function, visit the [Open Workflow Catalog](https://github.com/serverlessworkflow/catalog).
+For more information about authoring a new custom function, visit the [Open Workflow Catalog](https://github.com/open-workflow-specification/catalog).
 
 ##### Using a Custom Function
 
@@ -684,11 +684,11 @@ do:
 
 ##### Publishing a Custom Function
 
-Consider submitting your function to the [Open Workflow Function Catalog](https://github.com/serverlessworkflow/catalog). 
+Consider submitting your function to the [Open Workflow Function Catalog](https://github.com/open-workflow-specification/catalog). 
 
 This optional step allows users to discover and utilize your function, enhancing its visibility and usability within the Open Workflow Specification community. By registering your function, you contribute to a shared repository of resources that can streamline workflow development for others.
 
-For detailed instructions on how to contribute your custom function, please refer to the [CONTRIBUTING.md](https://github.com/serverlessworkflow/catalog/blob/main/CONTRIBUTING.md) file.
+For detailed instructions on how to contribute your custom function, please refer to the [CONTRIBUTING.md](https://github.com/open-workflow-specification/catalog/blob/main/CONTRIBUTING.md) file.
 
 ### Events
 

--- a/examples/call-asyncapi-subscribe-consume-forever-foreach.yaml
+++ b/examples/call-asyncapi-subscribe-consume-forever-foreach.yaml
@@ -22,7 +22,7 @@ do:
                     event:
                       with:
                         source: https://open-workflow-specification.org/samples
-                        type: io.serverlessworkflow.samples.asyncapi.message.consumed.v1
+                        type: io.open-workflow-specification.samples.asyncapi.message.consumed.v1
                         data:
                           message: '${ $message }'
                         

--- a/examples/call-custom-function-cataloged.yaml
+++ b/examples/call-custom-function-cataloged.yaml
@@ -5,7 +5,7 @@ document:
   version: '0.1.0'
 do:
   - log:
-      call: https://raw.githubusercontent.com/serverlessworkflow/catalog/main/functions/log/1.0.0/function.yaml
+      call: https://raw.githubusercontent.com/open-workflow-specification/catalog/main/functions/log/1.0.0/function.yaml
       with:
         message: Hello, world!
         level: information

--- a/examples/raise-inline.yaml
+++ b/examples/raise-inline.yaml
@@ -7,7 +7,7 @@ do:
   - notImplemented:
       raise:
         error:
-          type: https://serverlessworkflow.io/errors/not-implemented
+          type: https://open-workflow-specification.org/errors/not-implemented
           status: 500
           title: Not Implemented
           detail: ${ "The workflow '\( $workflow.definition.document.name ):\( $workflow.definition.document.version )' is a work in progress and cannot be run yet" }

--- a/examples/raise-reusable.yaml
+++ b/examples/raise-reusable.yaml
@@ -6,7 +6,7 @@ document:
 use:
   errors:
     notImplemented:
-      type: https://serverlessworkflow.io/errors/not-implemented
+      type: https://open-workflow-specification.org/errors/not-implemented
       status: 500
       title: Not Implemented
       detail: ${ "The workflow '\( $workflow.definition.document.name ):\( $workflow.definition.document.version )' is a work in progress and cannot be run yet" }

--- a/examples/set-expression.yaml
+++ b/examples/set-expression.yaml
@@ -7,7 +7,7 @@ schedule:
   on:
     one:
       with:
-        type: io.serverlessworkflow.samples.events.trigger.v1
+        type: io.open-workflow-specification.samples.events.trigger.v1
 do:
   - initialize:
       set: ${ $workflow.input[0] }

--- a/examples/set.yaml
+++ b/examples/set.yaml
@@ -7,7 +7,7 @@ schedule:
   on:
     one:
       with:
-        type: io.serverlessworkflow.samples.events.trigger.v1
+        type: io.open-workflow-specification.samples.events.trigger.v1
 do:
   - initialize:
       set:

--- a/examples/try-catch-then-directive.yaml
+++ b/examples/try-catch-then-directive.yaml
@@ -14,7 +14,7 @@ do:
       catch:
         errors:
           with:
-            type: https://serverlessworkflow.io/dsl/errors/types/communication
+            type: https://open-workflow-specification.org/dsl/errors/types/communication
             status: 503
         then: recordFailure
   - continueProcessing:


### PR DESCRIPTION
## Summary

This PR fixes #1188 by replacing all references to the old `serverlessworkflow` domain and organization with the new `open-workflow-specification` domain.

## Changes

- Replaced `serverlessworkflow.io` with `open-workflow-specification.org` in event URIs
- Updated `github.com/serverlessworkflow/*` to `github.com/open-workflow-specification/*`
- Changed `io.serverlessworkflow.*` event types to `io.open-workflow-specification.*`
- Updated catalog and `raw.githubusercontent.com` URLs to new organization
- Updated GitHub badge URLs to reference new organization

## Files Updated

- Event type URIs in examples (YAML files)
- Documentation (`dsl.md`, `dsl-reference.md`, `README.md`)
- Contributing guidelines and security documentation
- ADRs and CTK documentation

## Notes

- VS Code Marketplace URL kept as-is (to be reviewed separately)
- Historical ADR reference preserved for accuracy
- DNS from old domain redirects to new one, so this is not a breaking change

## Test Plan

- [x] Verified all `serverlessworkflow.io` references replaced
- [x] Verified all GitHub organization URLs updated
- [x] Verified all event type URIs updated
- [x] Only intentional references remain (Marketplace URL, historical ADR)